### PR TITLE
two column layout

### DIFF
--- a/src/Kodify/BlogBundle/Resources/public/css/blog.css
+++ b/src/Kodify/BlogBundle/Resources/public/css/blog.css
@@ -17,3 +17,9 @@ label {
 .thumbnail img {
     height: 200px;
 }
+
+#content .panel .panel-body {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/src/Kodify/BlogBundle/Resources/views/Post/List/index.html.twig
+++ b/src/Kodify/BlogBundle/Resources/views/Post/List/index.html.twig
@@ -2,16 +2,22 @@
 
 {% block content %}
 
-    {% for post in posts %}
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <a href="{{ path('view_post',{id: post.id}) }}">{{ post.title }}</a>
-                <span class="pull-right">by: {{ post.author.name }} on: {{ post.createdAt|date("m/d/Y") }}</span>
+    <div class="row">
+    
+        {% for post in posts %}
+            <div class="col-sm-6">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <a href="{{ path('view_post',{id: post.id}) }}">{{ post.title }}</a>
+                        <span class="pull-right">by: {{ post.author.name }} on: {{ post.createdAt|date("m/d/Y") }}</span>
+                    </div>
+                    <div class="panel-body">
+                        {{ post.content }}
+                    </div>
+                </div>
             </div>
-            <div class="panel-body">
-                {{ post.content }}
-            </div>
-        </div>
-    {% endfor %}
+        {% endfor %}
+    
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
This one didn’t take very long.

I used the bootstrap grid system to create a two column layout for the
blog posts on the main page. On very narrow screens, they are still
displayed in one column. I changed the css so that only one line of
text is shown for each blog post, because different heights would turn
the layout into chaos.
